### PR TITLE
[PR] RX 우선순위 > Timer(Scheduling) 우선순위 수정

### DIFF
--- a/tc275_project/src/OurCan.c
+++ b/tc275_project/src/OurCan.c
@@ -57,7 +57,7 @@ DBMessages db_msg;
 
 /*********************************************************************************************************************/
 /*---------------------------------------------Function Implementations----------------------------------------------*/
-IFX_INTERRUPT(RX_Int0Handler, 0, 10);
+IFX_INTERRUPT(RX_Int0Handler, 0, 101);
 // void RX_Int0Handler (void){}
 void RX_Int0Handler(void)
 {
@@ -530,7 +530,7 @@ void initCan(void)
     IfxMultican_Can_initModuleConfig(&canConfig, &MODULE_CAN);
 
     //     CAN0 인터럽트 활성화
-    canConfig.nodePointer[TC275_CAN0].priority = 10;
+    canConfig.nodePointer[TC275_CAN0].priority = 101;
     canConfig.nodePointer[TC275_CAN0].typeOfService = IfxSrc_Tos_cpu0;
 
     IfxMultican_Can_initModule(&can, &canConfig);


### PR DESCRIPTION
CAN Rx우선순위 10 ->101 로 Timer보다 높게 설정하였습니다.

Ref: 

Timer 인터럽트(1ms)와 CAN 통신 RX 인터럽트 중 어떤 인터럽트의 우선순위가 더 높아야 하는지는 시스템의 동작 목적과 요구사항에 따라 다릅니다. 하지만 일반적인 임베디드 시스템 설계에서 고려해야 할 사항을 기준으로 설명드리겠습니다.

CAN RX 인터럽트는 실시간성이 중요한 작업이므로, 다음과 같은 상황에서는 CAN RX 인터럽트의 우선순위를 높이는 것이 적절합니다:

실시간 데이터 처리 요구사항: CAN 통신은 네트워크로부터 들어오는 데이터를 수신해야 하며, 데이터 손실 없이 처리해야 합니다. 데이터 수신 지연이 발생하면 중요한 메시지가 누락될 수 있습니다.
데이터 수신량이 많거나 속도가 빠를 때: CAN RX 인터럽트가 빠르게 처리되지 않으면 수신 버퍼 오버플로가 발생할 수 있습니다. 이를 방지하려면 RX 인터럽트가 더 높은 우선순위를 가져야 합니다.
CAN 통신이 중요한 시스템: 예를 들어, 차량 제어 시스템처럼 CAN 통신 데이터가 시스템의 주요 입력이라면, CAN RX가 높은 우선순위를 가져야 합니다.

권장 우선순위 설정
CAN RX 인터럽트 > Timer 인터럽트:
CAN 통신이 실시간 데이터 처리를 요구하고, 데이터 손실이 시스템에 치명적일 경우.
예: 차량 네트워크에서 센서 데이터를 수신하는 시스템.

